### PR TITLE
Bump to latest sql version and set default targets to non deprecated ABIs.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,10 @@
 # /home/norbert/sqlite3-android/Makefile
 #
 .DEFAULT_GOAL		:= build
-SQLITE_AMALGATION	:= sqlite-amalgamation-3250200
+SQLITE_AMALGATION	:= sqlite-amalgamation-3250300
 SQLITE_SOURCEURL	:= https://sqlite.org/2018/$(SQLITE_AMALGATION).zip
 # TARGET ABI := armeabi armeabi-v7a arm64-v8a x86 x86_64 mips mips64 (or all)
-TARGET_ABI		:= armeabi
+TARGET_ABI		:= armeabi-v7a arm64-v8a x86 x86_64
 # URL_DOWNLOADER	:= wget -c
 URL_DOWNLOADER		:= aria2c -q -c -x 3
 CHECK_NDKPATH		:= $(shell which ndk-build >/dev/null 2>&1 ; echo $$?)


### PR DESCRIPTION
armeabi and mips targets throw a deprecation error when building with the latest NDK.
The rest works fine. Just tested. Nice repo :+1: 